### PR TITLE
Added Trig Ops

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -14,6 +14,11 @@ bool is_numeric(char c) {
   return char_code >= 48 & char_code <= 57;
 }
 
+bool is_alpha(char c) {
+  int char_code = (int)c;
+  return char_code >= 97 & char_code <= 122;
+}
+
 Token *create_token(char *type, char *value) {
   Token *token = malloc(sizeof(token));
   token->type = type;
@@ -99,7 +104,6 @@ Token **lexer(char *stream, int stream_length, int *size) {
             c = stream[cursor];
             str_num = realloc(str_num, buffer_idx* sizeof(char));
           }
-
           {
             Token* t = create_token("NUMBER", str_num);
             num_tokens++;
@@ -107,7 +111,60 @@ Token **lexer(char *stream, int stream_length, int *size) {
             tokens[num_tokens - 1] = t;
           }
           cursor--;
-        }      
+        } else if (is_alpha(c) && c == 's') {
+          char *trig_op = malloc(sizeof(char));
+          int buffer_idx = 0;
+          while (is_alpha(c) && cursor < stream_length) {
+            trig_op[buffer_idx] = c;
+            cursor++;
+            buffer_idx++;
+            c = stream[cursor];
+            trig_op = realloc(trig_op, buffer_idx* sizeof(char));            
+          }
+          {
+            Token* t = create_token("SIN", trig_op);
+            num_tokens++;
+            tokens = realloc(tokens, num_tokens * sizeof(Token *));
+            tokens[num_tokens - 1] = t;            
+          }
+          cursor--;
+        } else if (is_alpha(c) && c == 'c') {
+          char *trig_op = malloc(sizeof(char));
+          int buffer_idx = 0;
+          while (is_alpha(c) && cursor < stream_length) {
+            trig_op[buffer_idx] = c;
+            cursor++;
+            buffer_idx++;
+            c = stream[cursor];
+            trig_op = realloc(trig_op, buffer_idx* sizeof(char));            
+          }
+          {
+            Token* t = create_token("COS", trig_op);
+            num_tokens++;
+            tokens = realloc(tokens, num_tokens * sizeof(Token *));
+            tokens[num_tokens - 1] = t;            
+          }
+          cursor--;
+        } else if (is_alpha(c) && c == 't') {
+          char *trig_op = malloc(sizeof(char));
+          int buffer_idx = 0;
+          while (is_alpha(c) && cursor < stream_length) {
+            trig_op[buffer_idx] = c;
+            cursor++;
+            buffer_idx++;
+            c = stream[cursor];
+            trig_op = realloc(trig_op, buffer_idx* sizeof(char));            
+          }
+          {
+            Token* t = create_token("TAN", trig_op);
+            num_tokens++;
+            tokens = realloc(tokens, num_tokens * sizeof(Token *));
+            tokens[num_tokens - 1] = t;            
+          }
+          cursor--;
+        }
+
+
     }
     cursor++;
   }

--- a/lexer.h
+++ b/lexer.h
@@ -6,6 +6,7 @@ typedef struct Token {
 } Token;
 
 bool is_numeric(char c);
+bool is_alpha(char c);
 Token **lexer(char *stream, int stream_length, int *size);
 Token *create_token(char *type, char *value);
 void destroy_token(Token *token);

--- a/parser.c
+++ b/parser.c
@@ -1,12 +1,19 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <math.h>
 #include "parser.h"
 
-ParseObject* create_parsed_object(Token *token) {
+ParseObject *create_parsed_numeric_literal(double value, char *type) {
   ParseObject *p = malloc(sizeof(ParseObject));
-  p->value = atof(token->value);
-  p->type = "NumericLiteral";
+  p->value = value;
+  p->type = type;
+  return p;
+}
+
+ParseObject* create_parsed_object(Token *token) {
+  double value = atof(token->value);
+  ParseObject *p = create_parsed_numeric_literal(value, "NumericLiteral");
   return p;
 }
 
@@ -34,6 +41,33 @@ ParseObject* parse_factor(Token **tokens, int num_tokens, int *cursor) {
     eat_token(tokens, cursor, "RPAREN");
     return expr;
   }
+
+ if (strcmp(current_token->type, "SIN") == 0) {
+    eat_token(tokens, cursor, "SIN");
+    ParseObject *expr = parse_factor(tokens, num_tokens, cursor);
+    double value = sin(expr->value);
+    ParseObject *literal = create_parsed_numeric_literal(value, "NumericLiteral");
+    free(expr);
+    return literal;
+ }
+
+ if (strcmp(current_token->type, "COS") == 0) {
+    eat_token(tokens, cursor, "COS");
+    ParseObject *expr = parse_factor(tokens, num_tokens, cursor);
+    double value = cos(expr->value);
+    ParseObject *literal = create_parsed_numeric_literal(value, "NumericLiteral");
+    free(expr);
+    return literal;
+ } 
+
+ if (strcmp(current_token->type, "TAN") == 0) {
+    eat_token(tokens, cursor, "TAN");
+    ParseObject *expr = parse_factor(tokens, num_tokens, cursor);
+    double value = tan(expr->value);
+    ParseObject *literal = create_parsed_numeric_literal(value, "NumericLiteral");
+    free(expr);
+    return literal;
+ } 
 
   printf("SyntaxError: Expected parenthesis or integer input but instead received %s\n", current_token->value);
   exit(0);


### PR DESCRIPTION
Added support for `sin`, `cos`, and `tan`. The feature is currently limited to only `NumericLiterals` as inputs inside aforementioned trig functions, i.e.,
```
sin(10) // ok
sin(9 + 1) // not ok
```